### PR TITLE
fix: スコープ検証の contains 関数を正しい実装に置き換え

### DIFF
--- a/backend/handlers/oidc/token.go
+++ b/backend/handlers/oidc/token.go
@@ -230,7 +230,7 @@ func (h *TokenHandler) handleAuthorizationCodeGrant(c *gin.Context) {
 
 	// Generate ID token if openid scope is requested
 	var idToken string
-	if contains(authCode.Scope, "openid") {
+	if scopeContains(authCode.Scope, "openid") {
 		idToken, err = utils.GenerateIDToken(
 			user.Sub, user.Name, user.Email, user.Picture,
 			authCode.Nonce, client.ClientID, h.config.JWTIssuer,
@@ -366,6 +366,11 @@ func (h *TokenHandler) handleRefreshTokenGrant(c *gin.Context) {
 	})
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[:len(substr)+1] == substr+" " || s[len(s)-len(substr)-1:] == " "+substr || len(s) > len(substr)+1 && strings.Contains(s, " "+substr+" ")))
+func scopeContains(scopeStr, target string) bool {
+	for _, s := range strings.Fields(scopeStr) {
+		if s == target {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## 問題

`handlers/oidc/token.go` の `contains` 関数が壊れていた。

```go
// 旧実装（誤り）
func contains(s, substr string) bool {
    return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (
        s[:len(substr)+1] == substr+" " ||
        s[len(s)-len(substr)-1:] == " "+substr ||
        len(s) > len(substr)+1 && strings.Contains(s, " "+substr+" ")))
}
```

- `"openid"` を `"openid profile email"` から探すと先頭一致チェックが `s[:len("openid")+1] == "openid "` → 正しく動く
- `"email"` を `"openid profile email"` から探すと末尾チェックが `s[len-6-1:] == " email"` → 正しく動く
- しかし `"profile"` を `"openid profile email"` から探すと先頭・末尾の両チェックが外れ、`strings.Contains(s, " profile ")` に落ちる。スペースで囲まれた部分一致なので `"openid profile email"` では ` profile ` が存在せず **false を返す**（バグ）

ID トークンの生成判定がこの関数に依存していたため、`"openid profile email"` スコープで `"openid"` スコープの検出が偶然動いていたが、スコープ文字列の順序次第でサイレント誤動作するリスクがあった。

## 修正

`strings.Fields` でスペース区切り分割し、各トークンと完全一致するかチェックする `scopeContains` に置き換えた。

```go
func scopeContains(scopeStr, target string) bool {
    for _, s := range strings.Fields(scopeStr) {
        if s == target {
            return true
        }
    }
    return false
}
```

## テスト

`go test ./...` 全パス済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)