### PR TITLE
fix: 管理者パスワード検証を bcrypt に統一

### DIFF
--- a/backend/handlers/admin/auth.go
+++ b/backend/handlers/admin/auth.go
@@ -50,18 +50,10 @@ func (h *AuthHandler) HandleLogin(c *gin.Context) {
 		return
 	}
 
-	// Verify password using crypt (PostgreSQL's password hash)
-	var storedHash string
-	err = h.db.QueryRow(context.Background(), `
-		SELECT crypt($1, password_hash) = password_hash FROM admins WHERE id = $2
-	`, req.Password, admin.ID).Scan(&storedHash)
-
-	if err != nil || storedHash != "t" {
-		// Fallback to bcrypt comparison for backward compatibility
-		if err := bcrypt.CompareHashAndPassword([]byte(admin.PasswordHash), []byte(req.Password)); err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid credentials"})
-			return
-		}
+	// Verify password using bcrypt
+	if err := bcrypt.CompareHashAndPassword([]byte(admin.PasswordHash), []byte(req.Password)); err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid credentials"})
+		return
 	}
 
 	// Generate session token

--- a/database/init.sql
+++ b/database/init.sql
@@ -165,7 +165,7 @@ INSERT INTO "admins" ("username", "email", "password_hash")
 VALUES (
   'admin',
   'admin@example.com',
-  crypt('admin123', gen_salt('bf'))
+  '$2a$10$FjuuscaoMWzcR/QPFbP48OKh2tCeoxNHeuZ8v7P6zqZx2lmUMVMnO'
 ) ON CONFLICT (username) DO NOTHING;
 
 -- ====================================


### PR DESCRIPTION
## 問題

`handlers/admin/auth.go` のパスワード検証が常に失敗していた。

```go
// 旧実装（バグ）
var storedHash string
err = h.db.QueryRow(ctx, `
    SELECT crypt($1, password_hash) = password_hash FROM admins WHERE id = $2
`, req.Password, admin.ID).Scan(&storedHash)

if err != nil || storedHash != "t" {  // ← ここが問題
    if err := bcrypt.CompareHashAndPassword(...); err != nil {
        // 401 を返す
    }
}
```

`crypt(...) = password_hash` は PostgreSQL の `boolean` を返すが、Go 側の `string` 変数にスキャンされると `"true"` / `"false"` が入る。`"t"` との比較は常に失敗するため、必ず bcrypt フォールバックへ落ちる。さらに `init.sql` では `crypt('admin123', gen_salt('bf'))` で保存しているため、bcrypt との比較も一致しない。結果としてデフォルト管理者でログインできない。

## 修正

- PostgreSQL 側の検証を削除し `bcrypt.CompareHashAndPassword` に一本化
- `init.sql` の初期パスワードを bcrypt ハッシュ（`$2a$10$...`）に変更し、ハッシュ形式を統一

## 課題

既存のテストコード（`test/handlers/admin/auth_test.go`）はハンドラを実際に呼び出さず、意味のあるアサーションが存在しない。別途テストを充実させる必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)