### PR TITLE
test: テストコードを充実させ RFC/OIDC 仕様参照を追加

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pashagolub/pgxmock/v2 v2.12.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -84,6 +84,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/pashagolub/pgxmock/v2 v2.12.0 h1:IVRmQtVFNCoq7NOZ+PdfvB6fwnLJmEuWDhnc3yrDxBs=
+github.com/pashagolub/pgxmock/v2 v2.12.0/go.mod h1:D3YslkN/nJ4+umVqWmbwfSXugJIjPMChkGBG47OJpNw=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/backend/handlers/oidc/token_test.go
+++ b/backend/handlers/oidc/token_test.go
@@ -1,0 +1,107 @@
+package oidc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestScopeContains verifies that scopeContains correctly identifies scope tokens.
+//
+// Scope syntax:
+//   - RFC 6749 §3.3: "The value of the scope parameter is expressed as a list of
+//     space-delimited, case-sensitive strings."
+//     https://datatracker.ietf.org/doc/html/rfc6749#section-3.3
+//   - OpenID Connect Core 1.0 §3.1.2.1: Scope values "openid", "profile", "email"
+//     https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+//
+// NOTE: このテストは fix/scope-contains-bug PR が develop にマージされると通るようになる。
+func TestScopeContains(t *testing.T) {
+	tests := []struct {
+		name     string
+		scope    string
+		target   string
+		expected bool
+	}{
+		// --- 正常系 ---
+		{
+			// RFC 6749 §3.3: スコープが単一トークンの場合
+			name:     "single scope exact match",
+			scope:    "openid",
+			target:   "openid",
+			expected: true,
+		},
+		{
+			// RFC 6749 §3.3: リストの先頭にある場合
+			name:     "target is first in list",
+			scope:    "openid profile email",
+			target:   "openid",
+			expected: true,
+		},
+		{
+			// RFC 6749 §3.3: リストの中間にある場合（旧実装がサイレントに失敗していた回帰ケース）
+			name:     "target is middle in list (regression)",
+			scope:    "openid profile email",
+			target:   "profile",
+			expected: true,
+		},
+		{
+			// RFC 6749 §3.3: リストの末尾にある場合
+			name:     "target is last in list",
+			scope:    "openid profile email",
+			target:   "email",
+			expected: true,
+		},
+		// --- 異常系 ---
+		{
+			// RFC 6749 §3.3: スコープが存在しない場合
+			name:     "target not in list",
+			scope:    "openid profile",
+			target:   "email",
+			expected: false,
+		},
+		{
+			// RFC 6749 §3.3: 部分文字列はマッチしてはならない
+			name:     "partial match must not match",
+			scope:    "openid profile email",
+			target:   "open",
+			expected: false,
+		},
+		{
+			// RFC 6749 §3.3: 部分文字列はマッチしてはならない（suffix）
+			name:     "suffix partial match must not match",
+			scope:    "openid profile email",
+			target:   "id",
+			expected: false,
+		},
+		{
+			// 空のスコープリスト
+			name:     "empty scope string",
+			scope:    "",
+			target:   "openid",
+			expected: false,
+		},
+		{
+			// 空のターゲット
+			name:     "empty target",
+			scope:    "openid profile email",
+			target:   "",
+			expected: false,
+		},
+		{
+			// RFC 6749 §3.3: スコープは大文字小文字を区別する
+			name:     "case sensitive: uppercase should not match lowercase",
+			scope:    "openid profile email",
+			target:   "OpenID",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scopeContains(tt.scope, tt.target)
+			assert.Equal(t, tt.expected, got,
+				"scopeContains(%q, %q) = %v, want %v", tt.scope, tt.target, got, tt.expected)
+		})
+	}
+}

--- a/backend/test/handlers/admin/auth_test.go
+++ b/backend/test/handlers/admin/auth_test.go
@@ -1,112 +1,258 @@
 package admin_test
 
 import (
-"bytes"
-"encoding/json"
-"net/http"
-"net/http/httptest"
-"testing"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 
-"github.com/gin-gonic/gin"
-"github.com/stretchr/testify/assert"
+	"openid-aas/backend/config"
+	"openid-aas/backend/handlers/admin"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func init() {
-gin.SetMode(gin.TestMode)
+	gin.SetMode(gin.TestMode)
 }
 
-// TestHandleLogin_Success tests successful admin login
+func newTestConfig() *config.Config {
+	return &config.Config{
+		JWTIssuer:  "https://test.example.com",
+		ServerPort: "8080",
+	}
+}
+
+func mustBcrypt(t *testing.T, password string) string {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	require.NoError(t, err)
+	return string(hash)
+}
+
+// TestHandleLogin_Success は正しい認証情報でのログイン成功をテストする。
+//
+// 管理者セッションの発行フロー:
+//   - セッショントークンはサーバー側で生成されクライアントに返却される
+//   - 有効期限は24時間
 func TestHandleLogin_Success(t *testing.T) {
-// Arrange
-username := "testadmin"
-password := "testpassword"
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
 
-requestBody := map[string]string{
-"username": username,
-"password": password,
-}
-jsonBody, _ := json.Marshal(requestBody)
+	adminID := uuid.New()
+	hashedPassword := mustBcrypt(t, "testpassword")
 
-w := httptest.NewRecorder()
-c, _ := gin.CreateTestContext(w)
-c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/login", bytes.NewBuffer(jsonBody))
-c.Request.Header.Set("Content-Type", "application/json")
+	// SELECT クエリ: admin レコードを取得
+	mock.ExpectQuery(`SELECT id, username, email, password_hash FROM admins WHERE username`).
+		WithArgs("testadmin").
+		WillReturnRows(pgxmock.NewRows([]string{"id", "username", "email", "password_hash"}).
+			AddRow(adminID, "testadmin", "testadmin@example.com", hashedPassword))
 
-// Act & Assert
-assert.Equal(t, username, requestBody["username"])
-assert.NotEmpty(t, password)
-}
+	// INSERT: セッション作成
+	mock.ExpectExec(`INSERT INTO admin_sessions`).
+		WithArgs(adminID, pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 
-// TestHandleLogin_InvalidRequest tests login with invalid request body
-func TestHandleLogin_InvalidRequest(t *testing.T) {
-// Arrange
-requestBody := map[string]string{
-"username": "testadmin",
-// password is missing
-}
-jsonBody, _ := json.Marshal(requestBody)
+	handler := admin.NewAuthHandler(mock, newTestConfig())
 
-w := httptest.NewRecorder()
-c, _ := gin.CreateTestContext(w)
-c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/login", bytes.NewBuffer(jsonBody))
-c.Request.Header.Set("Content-Type", "application/json")
+	body, _ := json.Marshal(map[string]string{
+		"username": "testadmin",
+		"password": "testpassword",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/login", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
 
-// Act & Assert
-assert.NotContains(t, requestBody, "password")
-}
+	handler.HandleLogin(c)
 
-// TestHandleLogin_InvalidCredentials tests login with wrong credentials
-func TestHandleLogin_InvalidCredentials(t *testing.T) {
-// Arrange
-requestBody := map[string]string{
-"username": "wronguser",
-"password": "wrongpassword",
-}
-jsonBody, _ := json.Marshal(requestBody)
-
-w := httptest.NewRecorder()
-c, _ := gin.CreateTestContext(w)
-c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/login", bytes.NewBuffer(jsonBody))
-c.Request.Header.Set("Content-Type", "application/json")
-
-// Act & Assert
-// Expected: Should return 401 Unauthorized for invalid credentials
-assert.NotNil(t, c)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["session_token"])
+	assert.NotNil(t, resp["admin"])
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-// TestHandleLogout_Success tests successful logout
+// TestHandleLogin_WrongPassword は誤ったパスワードで401が返ることをテストする。
+func TestHandleLogin_WrongPassword(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	adminID := uuid.New()
+	hashedPassword := mustBcrypt(t, "correctpassword")
+
+	mock.ExpectQuery(`SELECT id, username, email, password_hash FROM admins WHERE username`).
+		WithArgs("testadmin").
+		WillReturnRows(pgxmock.NewRows([]string{"id", "username", "email", "password_hash"}).
+			AddRow(adminID, "testadmin", "testadmin@example.com", hashedPassword))
+
+	handler := admin.NewAuthHandler(mock, newTestConfig())
+
+	body, _ := json.Marshal(map[string]string{
+		"username": "testadmin",
+		"password": "wrongpassword",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/login", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler.HandleLogin(c)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestHandleLogin_UnknownUsername は存在しないユーザー名で401が返ることをテストする。
+// タイミング攻撃対策として、ユーザーが存在しない場合も同じ 401 を返す。
+func TestHandleLogin_UnknownUsername(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mock.ExpectQuery(`SELECT id, username, email, password_hash FROM admins WHERE username`).
+		WithArgs("nonexistent").
+		WillReturnError(assert.AnError)
+
+	handler := admin.NewAuthHandler(mock, newTestConfig())
+
+	body, _ := json.Marshal(map[string]string{
+		"username": "nonexistent",
+		"password": "anypassword",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/login", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler.HandleLogin(c)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestHandleLogin_MissingFields は必須フィールドが欠けたリクエストで400が返ることをテストする。
+func TestHandleLogin_MissingFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body map[string]string
+	}{
+		{"missing password", map[string]string{"username": "admin"}},
+		{"missing username", map[string]string{"password": "pass"}},
+		{"empty body", map[string]string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+
+			handler := admin.NewAuthHandler(mock, newTestConfig())
+
+			body, _ := json.Marshal(tt.body)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/login", bytes.NewBuffer(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			handler.HandleLogin(c)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+// TestHandleLogin_ResponseShape はレスポンスボディのフィールドをテストする。
+func TestHandleLogin_ResponseShape(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	adminID := uuid.New()
+	hashedPassword := mustBcrypt(t, "pass")
+
+	mock.ExpectQuery(`SELECT id, username, email, password_hash FROM admins WHERE username`).
+		WithArgs("admin").
+		WillReturnRows(pgxmock.NewRows([]string{"id", "username", "email", "password_hash"}).
+			AddRow(adminID, "admin", "admin@example.com", hashedPassword))
+	mock.ExpectExec(`INSERT INTO admin_sessions`).
+		WithArgs(adminID, pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	handler := admin.NewAuthHandler(mock, newTestConfig())
+
+	body, _ := json.Marshal(map[string]string{"username": "admin", "password": "pass"})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/login", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler.HandleLogin(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// レスポンスに必須フィールドが含まれることを確認
+	assert.Contains(t, resp, "session_token")
+	assert.Contains(t, resp, "expires_at")
+	assert.Contains(t, resp, "admin")
+
+	adminObj, ok := resp["admin"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, adminObj, "id")
+	assert.Contains(t, adminObj, "username")
+	assert.Contains(t, adminObj, "email")
+	// password_hash がレスポンスに含まれないことを確認（情報漏洩防止）
+	assert.NotContains(t, adminObj, "password_hash")
+}
+
+// TestHandleLogout_Success は正しいセッショントークンでのログアウトをテストする。
 func TestHandleLogout_Success(t *testing.T) {
-// Arrange
-sessionToken := "valid-session-token"
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
 
-w := httptest.NewRecorder()
-c, _ := gin.CreateTestContext(w)
-c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/logout", nil)
-c.Request.Header.Set("X-Session-Token", sessionToken)
+	mock.ExpectExec(`DELETE FROM admin_sessions WHERE session_token`).
+		WithArgs("valid-token").
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
-// Act & Assert
-assert.Equal(t, sessionToken, c.Request.Header.Get("X-Session-Token"))
+	handler := admin.NewAuthHandler(mock, newTestConfig())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/logout", nil)
+	c.Request.Header.Set("X-Session-Token", "valid-token")
+
+	handler.HandleLogout(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-// TestHandleLogout_NoSessionToken tests logout without session token
-func TestHandleLogout_NoSessionToken(t *testing.T) {
-// Arrange
-w := httptest.NewRecorder()
-c, _ := gin.CreateTestContext(w)
-c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/logout", nil)
+// TestHandleLogout_NoToken はセッショントークンなしで400が返ることをテストする。
+func TestHandleLogout_NoToken(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
 
-// Act & Assert
-// Expected: Should return 400 Bad Request when no session token provided
-assert.Empty(t, c.Request.Header.Get("X-Session-Token"))
-}
+	handler := admin.NewAuthHandler(mock, newTestConfig())
 
-// TestSessionTokenValidation tests session token validation logic
-func TestSessionTokenValidation(t *testing.T) {
-// Arrange
-validToken := "abc123xyz"
-emptyToken := ""
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/logout", nil)
 
-// Act & Assert
-assert.NotEmpty(t, validToken)
-assert.Empty(t, emptyToken)
+	handler.HandleLogout(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/backend/test/handlers/admin/clients_test.go
+++ b/backend/test/handlers/admin/clients_test.go
@@ -6,209 +6,243 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"openid-aas/backend/handlers/admin"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/pashagolub/pgxmock/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// TestHandleListClients_Success tests successful client listing
+// clientColumns は HandleListClients / HandleGetClient が SELECT するカラム一覧
+var clientColumns = []string{
+	"id", "client_id", "client_name",
+	"redirect_uris", "grant_types", "response_types",
+	"scope", "token_endpoint_auth_method",
+	"created_at", "updated_at",
+}
+
+// TestHandleListClients_Success はクライアント一覧の正常取得をテストする。
+//
+// Ref: RFC 7591 §2 (Dynamic Client Registration)
+//
+//	https://datatracker.ietf.org/doc/html/rfc7591#section-2
 func TestHandleListClients_Success(t *testing.T) {
-	// Arrange
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	clientID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery(`SELECT (.+) FROM clients`).
+		WillReturnRows(pgxmock.NewRows(clientColumns).
+			AddRow(
+				clientID, "client-abc", "Test Client",
+				pq.Array([]string{"https://app.example.com/callback"}),
+				pq.Array([]string{"authorization_code"}),
+				pq.Array([]string{"code"}),
+				"openid profile email", "client_secret_basic",
+				now, now,
+			))
+
+	handler := admin.NewClientsHandler(mock, newTestConfig())
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/clients", nil)
+	handler.HandleListClients(c)
 
-	// Act & Assert
-	// Expected: Should return list of clients with 200 OK
-	// cfg was not used in this test
-	assert.Equal(t, http.MethodGet, c.Request.Method)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	clients, ok := resp["clients"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, clients, 1)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-// TestHandleCreateClient_ValidData tests creating a new client
-func TestHandleCreateClient_ValidData(t *testing.T) {
-	// Arrange
+// TestHandleListClients_Empty は登録クライアントがゼロ件の場合に空配列が返ることをテストする。
+func TestHandleListClients_Empty(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
 
-	requestBody := map[string]interface{}{
-		"client_name":    "Test Client",
-		"redirect_uris":  []string{"https://example.com/callback"},
-		"grant_types":    []string{"authorization_code", "refresh_token"},
-		"response_types": []string{"code"},
-		"scope":          "openid profile email",
-	}
-	jsonBody, _ := json.Marshal(requestBody)
+	mock.ExpectQuery(`SELECT (.+) FROM clients`).
+		WillReturnRows(pgxmock.NewRows(clientColumns))
+
+	handler := admin.NewClientsHandler(mock, newTestConfig())
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/clients", bytes.NewBuffer(jsonBody))
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/clients", nil)
+	handler.HandleListClients(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	clients := resp["clients"].([]interface{})
+	assert.Empty(t, clients)
+}
+
+// TestHandleCreateClient_Success はクライアント作成の正常系をテストする。
+//
+// Ref: RFC 7591 §3.1 (Client Registration Request)
+//
+//	redirect_uris は REQUIRED。
+//	https://datatracker.ietf.org/doc/html/rfc7591#section-3.1
+func TestHandleCreateClient_Success(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	newID := uuid.New()
+	now := time.Now()
+
+	// INSERT ... RETURNING
+	mock.ExpectQuery(`INSERT INTO clients`).
+		WillReturnRows(pgxmock.NewRows(clientColumns).
+			AddRow(
+				newID, "generated-client-id", "My App",
+				pq.Array([]string{"https://app.example.com/callback"}),
+				pq.Array([]string{"authorization_code"}),
+				pq.Array([]string{"code"}),
+				"openid profile email", "client_secret_basic",
+				now, now,
+			))
+
+	handler := admin.NewClientsHandler(mock, newTestConfig())
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"client_name":   "My App",
+		"redirect_uris": []string{"https://app.example.com/callback"},
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/clients", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
+	handler.HandleCreateClient(c)
 
-	// Act & Assert
-	// Expected: Should create client and return 201 Created with client_id and client_secret
-	// cfg was not used in this test
-	assert.Contains(t, string(jsonBody), "Test Client")
+	require.Equal(t, http.StatusCreated, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	// 作成直後のみ client_secret が返る
+	assert.NotEmpty(t, resp["client_secret"], "client_secret must be returned on creation only")
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-// TestHandleCreateClient_MissingName tests creating client without name
-func TestHandleCreateClient_MissingName(t *testing.T) {
-	// Arrange
-
-	requestBody := map[string]interface{}{
-		// client_name is missing
-		"redirect_uris": []string{"https://example.com/callback"},
-	}
-	jsonBody, _ := json.Marshal(requestBody)
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/clients", bytes.NewBuffer(jsonBody))
-	c.Request.Header.Set("Content-Type", "application/json")
-
-	// Act & Assert
-	// Expected: Should return 400 Bad Request when client_name is missing
-	// cfg was not used in this test
-	assert.NotContains(t, string(jsonBody), "client_name")
-}
-
-// TestHandleCreateClient_InvalidRedirectURI tests creating client with invalid redirect URI
-func TestHandleCreateClient_InvalidRedirectURI(t *testing.T) {
-	// Arrange
-
-	requestBody := map[string]interface{}{
-		"client_name":   "Test Client",
-		"redirect_uris": []string{"not-a-valid-url"},
-	}
-	jsonBody, _ := json.Marshal(requestBody)
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/clients", bytes.NewBuffer(jsonBody))
-	c.Request.Header.Set("Content-Type", "application/json")
-
-	// Act & Assert
-	// Expected: Should return 400 Bad Request for invalid redirect URI
-	// cfg was not used in this test
-}
-
-// TestHandleGetClient_ValidID tests getting a specific client
-func TestHandleGetClient_ValidID(t *testing.T) {
-	// Arrange
-	clientID := uuid.New().String()
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/clients/"+clientID, nil)
-	c.Params = gin.Params{{Key: "id", Value: clientID}}
-
-	// Act
-	retrievedID := c.Param("id")
-
-	// Assert
-	assert.Equal(t, clientID, retrievedID)
-}
-
-// TestHandleGetClient_InvalidID tests getting client with invalid ID
-func TestHandleGetClient_InvalidID(t *testing.T) {
-	// Arrange
-	invalidID := "not-a-uuid"
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/clients/"+invalidID, nil)
-	c.Params = gin.Params{{Key: "id", Value: invalidID}}
-
-	// Act
-	_, err := uuid.Parse(invalidID)
-
-	// Assert
-	// Expected: Should return 400 Bad Request for invalid UUID
-	assert.Error(t, err)
-}
-
-// TestHandleDeleteClient_ValidID tests deleting a client
-func TestHandleDeleteClient_ValidID(t *testing.T) {
-	// Arrange
-	clientID := uuid.New().String()
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodDelete, "/api/admin/clients/"+clientID, nil)
-	c.Params = gin.Params{{Key: "id", Value: clientID}}
-
-	// Act & Assert
-	// Expected: Should delete client and return 200 OK
-	// cfg was not used in this test
-}
-
-// TestHandleDeleteClient_WithActiveTokens tests deleting client with active tokens
-func TestHandleDeleteClient_WithActiveTokens(t *testing.T) {
-	// Arrange
-	clientID := uuid.New().String()
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodDelete, "/api/admin/clients/"+clientID, nil)
-	c.Params = gin.Params{{Key: "id", Value: clientID}}
-
-	// Act & Assert
-	// Expected: Should cascade delete client and revoke all associated tokens
-	// cfg was not used in this test
-}
-
-// TestClientIDGeneration tests client ID uniqueness
-func TestClientIDGeneration(t *testing.T) {
-	// Arrange
-	clientID1 := uuid.New().String()
-	clientID2 := uuid.New().String()
-
-	// Act & Assert
-	// Expected: Each generated client ID should be unique
-	assert.NotEqual(t, clientID1, clientID2)
-}
-
-// TestClientSecretGeneration tests client secret generation requirements
-func TestClientSecretGeneration(t *testing.T) {
-	// Arrange
-	// Client secret should be cryptographically secure random string
-	minSecretLength := 32
-
-	// Act & Assert
-	// Expected: Client secret should have sufficient entropy and length
-	// Test that the minimum length requirement is reasonable
-	assert.Greater(t, minSecretLength, 16, "Secret should be at least 16 characters for security")
-	assert.LessOrEqual(t, minSecretLength, 128, "Secret should not exceed reasonable maximum length")
-}
-
-// TestHandleCreateClient_GrantTypes tests valid grant types
-func TestHandleCreateClient_GrantTypes(t *testing.T) {
-	// Arrange
-	validGrantTypes := []string{
-		"authorization_code",
-		"refresh_token",
-		"client_credentials",
+// TestHandleCreateClient_MissingRequiredFields は必須フィールド欠落で400が返ることをテストする。
+//
+// Ref: RFC 7591 §3.2.2 (Client Registration Error Response)
+//
+//	https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.2
+func TestHandleCreateClient_MissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body map[string]interface{}
+	}{
+		{"missing client_name", map[string]interface{}{"redirect_uris": []string{"https://example.com"}}},
+		{"missing redirect_uris", map[string]interface{}{"client_name": "App"}},
 	}
 
-	// Act & Assert
-	for _, grantType := range validGrantTypes {
-		assert.NotEmpty(t, grantType)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+
+			handler := admin.NewClientsHandler(mock, newTestConfig())
+
+			body, _ := json.Marshal(tt.body)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/api/admin/clients", bytes.NewBuffer(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+			handler.HandleCreateClient(c)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
 	}
 }
 
-// TestHandleCreateClient_ResponseTypes tests valid response types
-func TestHandleCreateClient_ResponseTypes(t *testing.T) {
-	// Arrange
-	validResponseTypes := []string{
-		"code",
-		"token",
-		"id_token",
-		"code token",
-		"code id_token",
-	}
+// TestHandleGetClient_Success はクライアント取得の正常系をテストする。
+func TestHandleGetClient_Success(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
 
-	// Act & Assert
-	for _, responseType := range validResponseTypes {
-		assert.NotEmpty(t, responseType)
-	}
+	clientID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery(`SELECT (.+) FROM clients WHERE id`).
+		WithArgs(clientID.String()).
+		WillReturnRows(pgxmock.NewRows(clientColumns).
+			AddRow(
+				clientID, "client-abc", "Test Client",
+				pq.Array([]string{"https://app.example.com/callback"}),
+				pq.Array([]string{"authorization_code"}),
+				pq.Array([]string{"code"}),
+				"openid profile email", "client_secret_basic",
+				now, now,
+			))
+
+	handler := admin.NewClientsHandler(mock, newTestConfig())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/clients/"+clientID.String(), nil)
+	c.Params = gin.Params{{Key: "id", Value: clientID.String()}}
+	handler.HandleGetClient(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestHandleGetClient_NotFound は存在しないクライアントで404が返ることをテストする。
+func TestHandleGetClient_NotFound(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	clientID := uuid.New()
+	mock.ExpectQuery(`SELECT (.+) FROM clients WHERE id`).
+		WithArgs(clientID.String()).
+		WillReturnRows(pgxmock.NewRows(clientColumns)) // 0件
+
+	handler := admin.NewClientsHandler(mock, newTestConfig())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/clients/"+clientID.String(), nil)
+	c.Params = gin.Params{{Key: "id", Value: clientID.String()}}
+	handler.HandleGetClient(c)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestHandleDeleteClient_Success はクライアント削除の正常系をテストする。
+func TestHandleDeleteClient_Success(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	clientID := uuid.New()
+	mock.ExpectExec(`DELETE FROM clients WHERE id`).
+		WithArgs(clientID.String()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+
+	handler := admin.NewClientsHandler(mock, newTestConfig())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/api/admin/clients/"+clientID.String(), nil)
+	c.Params = gin.Params{{Key: "id", Value: clientID.String()}}
+	handler.HandleDeleteClient(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/backend/test/handlers/admin/users_test.go
+++ b/backend/test/handlers/admin/users_test.go
@@ -1,171 +1,159 @@
 package admin_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"openid-aas/backend/handlers/admin"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// TestHandleListUsers_Success tests successful user listing
+var userColumns = []string{
+	"id", "sub", "name", "email", "email_verified", "picture", "created_at", "updated_at",
+}
+
+// TestHandleListUsers_Success はユーザー一覧の正常取得をテストする。
+//
+// Ref: OpenID Connect Core 1.0 §5.1 (Standard Claims)
+//
+//	sub, name, email, email_verified, picture は標準クレームとして定義されている。
+//	https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
 func TestHandleListUsers_Success(t *testing.T) {
-	// Arrange
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	userID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery(`SELECT (.+) FROM users`).
+		WillReturnRows(pgxmock.NewRows(userColumns).
+			AddRow(userID, "github_12345", "Test User", "test@example.com", true, "", now, now))
+
+	handler := admin.NewUsersHandler(mock, newTestConfig())
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
+	handler.HandleListUsers(c)
 
-	// Act & Assert
-	// Expected: Should return list of users with 200 OK
-	// cfg was not used in this test
-	assert.Equal(t, http.MethodGet, c.Request.Method)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	users, ok := resp["users"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, users, 1)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-// TestHandleListUsers_EmptyDatabase tests user listing with no users
-func TestHandleListUsers_EmptyDatabase(t *testing.T) {
-	// Arrange
+// TestHandleListUsers_Empty はユーザーゼロ件の場合に空配列が返ることをテストす���。
+func TestHandleListUsers_Empty(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mock.ExpectQuery(`SELECT (.+) FROM users`).
+		WillReturnRows(pgxmock.NewRows(userColumns))
+
+	handler := admin.NewUsersHandler(mock, newTestConfig())
+
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
+	handler.HandleListUsers(c)
 
-	// Act & Assert
-	// Expected: Should return empty array with 200 OK
-	assert.NotNil(t, c)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp["users"].([]interface{}))
 }
 
-// TestHandleGetUser_ValidID tests getting a specific user
-func TestHandleGetUser_ValidID(t *testing.T) {
-	// Arrange
-	userID := uuid.New().String()
+// TestHandleGetUser_Success はユーザー取得の正常系をテス��する。
+// プロバイダー連携情報も合わせて返す。
+func TestHandleGetUser_Success(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	userID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery(`SELECT (.+) FROM users WHERE id`).
+		WithArgs(userID.String()).
+		WillReturnRows(pgxmock.NewRows(userColumns).
+			AddRow(userID, "github_12345", "Test User", "test@example.com", true, "", now, now))
+
+	mock.ExpectQuery(`SELECT (.+) FROM user_providers WHERE user_id`).
+		WithArgs(userID.String()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "provider", "provider_user_id", "scope", "created_at"}).
+			AddRow(uuid.New().String(), "github", "12345", "user:email read:user", now))
+
+	handler := admin.NewUsersHandler(mock, newTestConfig())
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/users/"+userID, nil)
-	c.Params = gin.Params{{Key: "id", Value: userID}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/users/"+userID.String(), nil)
+	c.Params = gin.Params{{Key: "id", Value: userID.String()}}
+	handler.HandleGetUser(c)
 
-	// Act
-	retrievedID := c.Param("id")
-
-	// Assert
-	assert.Equal(t, userID, retrievedID)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Contains(t, resp, "user")
+	assert.Contains(t, resp, "providers")
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-// TestHandleGetUser_InvalidID tests getting user with invalid ID format
-func TestHandleGetUser_InvalidID(t *testing.T) {
-	// Arrange
-	invalidID := "not-a-uuid"
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/users/"+invalidID, nil)
-	c.Params = gin.Params{{Key: "id", Value: invalidID}}
-
-	// Act
-	retrievedID := c.Param("id")
-	_, err := uuid.Parse(retrievedID)
-
-	// Assert
-	// Expected: Should return 400 Bad Request for invalid UUID
-	assert.Error(t, err)
-}
-
-// TestHandleGetUser_NotFound tests getting non-existent user
+// TestHandleGetUser_NotFound ��存在しないユーザーで404が返ることをテストする。
 func TestHandleGetUser_NotFound(t *testing.T) {
-	// Arrange
-	userID := uuid.New().String() // Valid UUID but doesn't exist
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	userID := uuid.New()
+	mock.ExpectQuery(`SELECT (.+) FROM users WHERE id`).
+		WithArgs(userID.String()).
+		WillReturnRows(pgxmock.NewRows(userColumns))
+
+	handler := admin.NewUsersHandler(mock, newTestConfig())
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/users/"+userID, nil)
-	c.Params = gin.Params{{Key: "id", Value: userID}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/users/"+userID.String(), nil)
+	c.Params = gin.Params{{Key: "id", Value: userID.String()}}
+	handler.HandleGetUser(c)
 
-	// Act & Assert
-	// Expected: Should return 404 Not Found for non-existent user
-	// cfg was not used in this test
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
-// TestHandleDeleteUser_ValidID tests deleting a user
-func TestHandleDeleteUser_ValidID(t *testing.T) {
-	// Arrange
-	userID := uuid.New().String()
+// TestHandleDeleteUser_Success はユーザー削除の正常系��テストする。
+// CASCADE により user_providers も削除される（DB制約で保証）。
+func TestHandleDeleteUser_Success(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	userID := uuid.New()
+	mock.ExpectExec(`DELETE FROM users WHERE id`).
+		WithArgs(userID.String()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+
+	handler := admin.NewUsersHandler(mock, newTestConfig())
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodDelete, "/api/admin/users/"+userID, nil)
-	c.Params = gin.Params{{Key: "id", Value: userID}}
+	c.Request = httptest.NewRequest(http.MethodDelete, "/api/admin/users/"+userID.String(), nil)
+	c.Params = gin.Params{{Key: "id", Value: userID.String()}}
+	handler.HandleDeleteUser(c)
 
-	// Act & Assert
-	// Expected: Should delete user and return 200 OK
-	// cfg was not used in this test
-}
-
-// TestHandleDeleteUser_InvalidID tests deleting with invalid ID
-func TestHandleDeleteUser_InvalidID(t *testing.T) {
-	// Arrange
-	invalidID := "not-a-uuid"
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodDelete, "/api/admin/users/"+invalidID, nil)
-	c.Params = gin.Params{{Key: "id", Value: invalidID}}
-
-	// Act
-	_, err := uuid.Parse(invalidID)
-
-	// Assert
-	// Expected: Should return 400 Bad Request for invalid UUID
-	assert.Error(t, err)
-}
-
-// TestHandleDeleteUser_WithProviders tests deleting user with connected providers
-func TestHandleDeleteUser_WithProviders(t *testing.T) {
-	// Arrange
-	userID := uuid.New().String()
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodDelete, "/api/admin/users/"+userID, nil)
-	c.Params = gin.Params{{Key: "id", Value: userID}}
-
-	// Act & Assert
-	// Expected: Should cascade delete user and their provider connections
-	// cfg was not used in this test
-}
-
-// TestHandleListUsers_Pagination tests user listing with pagination
-func TestHandleListUsers_Pagination(t *testing.T) {
-	// Arrange
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/users?page=1&limit=10", nil)
-
-	// Act
-	page := c.DefaultQuery("page", "1")
-	limit := c.DefaultQuery("limit", "10")
-
-	// Assert
-	assert.Equal(t, "1", page)
-	assert.Equal(t, "10", limit)
-}
-
-// TestHandleListUsers_Sorting tests user listing with sorting
-func TestHandleListUsers_Sorting(t *testing.T) {
-	// Arrange
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodGet, "/api/admin/users?sort=created_at&order=desc", nil)
-
-	// Act
-	sortField := c.DefaultQuery("sort", "created_at")
-	sortOrder := c.DefaultQuery("order", "desc")
-
-	// Assert
-	assert.Equal(t, "created_at", sortField)
-	assert.Equal(t, "desc", sortOrder)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/backend/test/handlers/middleware/auth_test.go
+++ b/backend/test/handlers/middleware/auth_test.go
@@ -1,130 +1,116 @@
 package middleware_test
 
 import (
-"net/http"
-"net/http/httptest"
-"testing"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 
-"github.com/gin-gonic/gin"
-"github.com/stretchr/testify/assert"
+	"openid-aas/backend/handlers/middleware"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
-gin.SetMode(gin.TestMode)
+	gin.SetMode(gin.TestMode)
 }
 
-// TestAuthMiddleware_MissingToken tests authentication middleware without token
-func TestAuthMiddleware_MissingToken(t *testing.T) {
-// Arrange
-w := httptest.NewRecorder()
-c, _ := gin.CreateTestContext(w)
-c.Request = httptest.NewRequest(http.MethodGet, "/protected", nil)
-// No X-Session-Token header set
+// TestAdminAuth_ValidToken は有効なセッショントークンで認証が通ることをテストする。
+func TestAdminAuth_ValidToken(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
 
-// Act
-sessionToken := c.GetHeader("X-Session-Token")
+	adminID := uuid.New()
+	mock.ExpectQuery(`SELECT admin_id FROM admin_sessions WHERE session_token`).
+		WithArgs("valid-token").
+		WillReturnRows(pgxmock.NewRows([]string{"admin_id"}).AddRow(adminID))
 
-// Assert
-// Expected: Should abort with 401 Unauthorized when token is missing
-assert.Empty(t, sessionToken)
+	router := gin.New()
+	router.GET("/protected", middleware.AdminAuth(mock), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("X-Session-Token", "valid-token")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-// TestAuthMiddleware_ValidTokenHeader tests auth middleware with valid token header
-func TestAuthMiddleware_ValidTokenHeader(t *testing.T) {
-// Arrange
-w := httptest.NewRecorder()
-c, _ := gin.CreateTestContext(w)
-c.Request = httptest.NewRequest(http.MethodGet, "/protected", nil)
-expectedToken := "valid-session-token-123"
-c.Request.Header.Set("X-Session-Token", expectedToken)
+// TestAdminAuth_ValidToken_SetsAdminID は認証後に admin_id がコンテキストにセットされることをテストする。
+func TestAdminAuth_ValidToken_SetsAdminID(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
 
-// Act
-sessionToken := c.GetHeader("X-Session-Token")
+	adminID := uuid.New()
+	mock.ExpectQuery(`SELECT admin_id FROM admin_sessions WHERE session_token`).
+		WithArgs("valid-token").
+		WillReturnRows(pgxmock.NewRows([]string{"admin_id"}).AddRow(adminID))
 
-// Assert
-assert.Equal(t, expectedToken, sessionToken)
-assert.NotEmpty(t, sessionToken)
+	var capturedAdminID interface{}
+	router := gin.New()
+	router.GET("/protected", middleware.AdminAuth(mock), func(c *gin.Context) {
+		capturedAdminID = c.MustGet("admin_id")
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("X-Session-Token", "valid-token")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, adminID, capturedAdminID)
 }
 
-// TestAuthMiddleware_TokenExtraction tests token extraction logic
-func TestAuthMiddleware_TokenExtraction(t *testing.T) {
-tests := []struct {
-name          string
-headerValue   string
-expectedEmpty bool
-}{
-{
-name:          "Valid token",
-headerValue:   "session-token-123",
-expectedEmpty: false,
-},
-{
-name:          "Empty token",
-headerValue:   "",
-expectedEmpty: true,
-},
-{
-name:          "Whitespace token",
-headerValue:   "   ",
-expectedEmpty: false,
-},
+// TestAdminAuth_MissingToken はトークンなしで401が返ることをテストする。
+func TestAdminAuth_MissingToken(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	router := gin.New()
+	router.GET("/protected", middleware.AdminAuth(mock), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	// DB クエリは実行されないことを確認
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-// Arrange
-w := httptest.NewRecorder()
-c, _ := gin.CreateTestContext(w)
-c.Request = httptest.NewRequest(http.MethodGet, "/protected", nil)
-if tt.headerValue != "" {
-c.Request.Header.Set("X-Session-Token", tt.headerValue)
-}
+// TestAdminAuth_ExpiredOrInvalidToken は無効・期限切れトークンで401が返ることをテストする。
+func TestAdminAuth_ExpiredOrInvalidToken(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
 
-// Act
-sessionToken := c.GetHeader("X-Session-Token")
+	// DB がレコードなしを返す（トークン無効または期限切れ）
+	mock.ExpectQuery(`SELECT admin_id FROM admin_sessions WHERE session_token`).
+		WithArgs("expired-token").
+		WillReturnRows(pgxmock.NewRows([]string{"admin_id"})) // 空の結果セット
 
-// Assert
-if tt.expectedEmpty {
-assert.Empty(t, sessionToken)
-} else {
-assert.NotEmpty(t, sessionToken)
-}
-})
-}
-}
+	router := gin.New()
+	router.GET("/protected", middleware.AdminAuth(mock), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
 
-// TestAuthMiddleware_MultipleHeaders tests handling of duplicate headers
-func TestAuthMiddleware_MultipleHeaders(t *testing.T) {
-// Arrange
-w := httptest.NewRecorder()
-c, _ := gin.CreateTestContext(w)
-c.Request = httptest.NewRequest(http.MethodGet, "/protected", nil)
-c.Request.Header.Set("X-Session-Token", "token1")
-// Setting again should overwrite
-c.Request.Header.Set("X-Session-Token", "token2")
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("X-Session-Token", "expired-token")
+	router.ServeHTTP(w, req)
 
-// Act
-sessionToken := c.GetHeader("X-Session-Token")
-
-// Assert
-// Should get the last set value
-assert.Equal(t, "token2", sessionToken)
-}
-
-// TestAuthMiddleware_CaseSensitivity tests header name case sensitivity
-func TestAuthMiddleware_CaseSensitivity(t *testing.T) {
-// Arrange
-w := httptest.NewRecorder()
-c, _ := gin.CreateTestContext(w)
-c.Request = httptest.NewRequest(http.MethodGet, "/protected", nil)
-c.Request.Header.Set("X-Session-Token", "mytoken")
-
-// Act
-// HTTP headers are case-insensitive
-token1 := c.GetHeader("X-Session-Token")
-token2 := c.GetHeader("x-session-token")
-
-// Assert
-assert.Equal(t, token1, token2)
-assert.NotEmpty(t, token1)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/backend/test/handlers/oidc/discovery_test.go
+++ b/backend/test/handlers/oidc/discovery_test.go
@@ -1,6 +1,7 @@
 package oidc_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,110 +12,228 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
 	gin.SetMode(gin.TestMode)
 }
 
-// TestDiscoveryHandler_Success tests OIDC discovery endpoint
-func TestDiscoveryHandler_Success(t *testing.T) {
-	// Arrange
-	cfg := &config.Config{
-		ServerHost:  "https://test.example.com",
-		JWTIssuer:   "https://test.example.com",
+func newDiscoveryCfg() *config.Config {
+	return &config.Config{
+		ServerHost: "https://test.example.com",
+		JWTIssuer:  "https://test.example.com",
 	}
+}
 
-	handler := oidc.NewDiscoveryHandler(cfg)
-	
+// TestDiscovery_RequiredFields は OpenID Connect Discovery ドキュメントに
+// 必須フィールドが全て含まれることを検証する。
+//
+// Ref: OpenID Connect Discovery 1.0 §3
+//
+//	https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+func TestDiscovery_RequiredFields(t *testing.T) {
+	handler := oidc.NewDiscoveryHandler(newDiscoveryCfg())
+
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
-
-	// Act
 	handler.HandleWellKnown(c)
 
-	// Assert
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), "issuer")
-	assert.Contains(t, w.Body.String(), "authorization_endpoint")
-	assert.Contains(t, w.Body.String(), "token_endpoint")
-	assert.Contains(t, w.Body.String(), "userinfo_endpoint")
-	assert.Contains(t, w.Body.String(), "jwks_uri")
+	require.Equal(t, http.StatusOK, w.Code)
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+
+	// OpenID Connect Discovery 1.0 §3 で REQUIRED なフィールド
+	requiredFields := []string{
+		"issuer",
+		"authorization_endpoint",
+		"token_endpoint",
+		"jwks_uri",
+		"response_types_supported",
+		"subject_types_supported",
+		"id_token_signing_alg_values_supported",
+	}
+	for _, field := range requiredFields {
+		assert.Contains(t, doc, field, "required field %q missing", field)
+	}
 }
 
-// TestDiscoveryHandler_ResponseFormat tests discovery response format
-func TestDiscoveryHandler_ResponseFormat(t *testing.T) {
-	// Arrange
-	cfg := &config.Config{
-		ServerHost:  "https://test.example.com",
-		JWTIssuer:   "https://test.example.com",
-	}
-
+// TestDiscovery_IssuerMatchesConfig は issuer が JWTIssuer と一致することを検証する。
+//
+// Ref: OpenID Connect Discovery 1.0 §3
+//
+//	"The iss value returned MUST be identical to the Issuer URL that was
+//	 directly used to retrieve the configuration information."
+//	https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+func TestDiscovery_IssuerMatchesConfig(t *testing.T) {
+	issuer := "https://auth.example.com"
+	cfg := &config.Config{JWTIssuer: issuer, ServerHost: issuer}
 	handler := oidc.NewDiscoveryHandler(cfg)
-	
+
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
-
-	// Act
 	handler.HandleWellKnown(c)
 
-	// Assert
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+	assert.Equal(t, issuer, doc["issuer"])
 }
 
-// TestJWKSHandler_Success tests JWKS endpoint
-func TestJWKSHandler_Success(t *testing.T) {
-	// Arrange
-	// Initialize keys before testing JWKS
-	err := utils.InitializeKeys()
-	if err != nil {
-		t.Fatalf("Failed to initialize keys: %v", err)
-	}
-
-	cfg := &config.Config{
-		ServerHost: "https://test.example.com",
-	}
-
+// TestDiscovery_EndpointURLs はエンドポイント URL が issuer を基底として構成されることを検証する。
+//
+// Ref: OpenID Connect Discovery 1.0 §3
+//
+//	https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+func TestDiscovery_EndpointURLs(t *testing.T) {
+	issuer := "https://test.example.com"
+	cfg := &config.Config{JWTIssuer: issuer, ServerHost: issuer}
 	handler := oidc.NewDiscoveryHandler(cfg)
-	
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	handler.HandleWellKnown(c)
+
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+
+	assert.Equal(t, issuer+"/oauth/authorize", doc["authorization_endpoint"])
+	assert.Equal(t, issuer+"/oauth/token", doc["token_endpoint"])
+	assert.Equal(t, issuer+"/oauth/userinfo", doc["userinfo_endpoint"])
+	assert.Equal(t, issuer+"/oauth/jwks", doc["jwks_uri"])
+}
+
+// TestDiscovery_SupportedAlgorithms は署名アルゴリズムに RS256 が含まれることを検証する。
+//
+// Ref: OpenID Connect Core 1.0 §10.1
+//
+//	"Servers MUST support RS256."
+//	https://openid.net/specs/openid-connect-core-1_0.html#SigEnc
+func TestDiscovery_SupportedAlgorithms(t *testing.T) {
+	handler := oidc.NewDiscoveryHandler(newDiscoveryCfg())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	handler.HandleWellKnown(c)
+
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+
+	algs, ok := doc["id_token_signing_alg_values_supported"].([]interface{})
+	require.True(t, ok)
+	var algStrs []string
+	for _, a := range algs {
+		algStrs = append(algStrs, a.(string))
+	}
+	assert.Contains(t, algStrs, "RS256")
+}
+
+// TestDiscovery_PKCEMethods は PKCE の S256 メソッドがサポートされていることを検証する。
+//
+// Ref: RFC 7636 §4.2
+//
+//	"If the client is capable of using "S256", it MUST use "S256"."
+//	https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
+func TestDiscovery_PKCEMethods(t *testing.T) {
+	handler := oidc.NewDiscoveryHandler(newDiscoveryCfg())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	handler.HandleWellKnown(c)
+
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+
+	methods, ok := doc["code_challenge_methods_supported"].([]interface{})
+	require.True(t, ok, "code_challenge_methods_supported must be present")
+	var methodStrs []string
+	for _, m := range methods {
+		methodStrs = append(methodStrs, m.(string))
+	}
+	assert.Contains(t, methodStrs, "S256", "S256 must be supported per RFC 7636")
+}
+
+// TestDiscovery_GrantTypes は authorization_code と refresh_token がサポートされることを検証する。
+//
+// Ref: RFC 6749 §4.1 (Authorization Code Grant)
+//
+//	https://datatracker.ietf.org/doc/html/rfc6749#section-4.1
+//
+// Ref: RFC 6749 §6 (Refreshing an Access Token)
+//
+//	https://datatracker.ietf.org/doc/html/rfc6749#section-6
+func TestDiscovery_GrantTypes(t *testing.T) {
+	handler := oidc.NewDiscoveryHandler(newDiscoveryCfg())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	handler.HandleWellKnown(c)
+
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+
+	grantTypes, ok := doc["grant_types_supported"].([]interface{})
+	require.True(t, ok)
+	var grantStrs []string
+	for _, g := range grantTypes {
+		grantStrs = append(grantStrs, g.(string))
+	}
+	assert.Contains(t, grantStrs, "authorization_code")
+	assert.Contains(t, grantStrs, "refresh_token")
+}
+
+// TestDiscovery_ContentType は Content-Type が application/json であることを検証する。
+//
+// Ref: OpenID Connect Discovery 1.0 §4
+//
+//	https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse
+func TestDiscovery_ContentType(t *testing.T) {
+	handler := oidc.NewDiscoveryHandler(newDiscoveryCfg())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	handler.HandleWellKnown(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+}
+
+// TestJWKS_RequiredFields は JWKS レスポンスに必須フィールドが含まれることを検証する。
+//
+// Ref: RFC 7517 §4 (JSON Web Key Parameters)
+//
+//	"kty" は REQUIRED。RSA 鍵には "n" と "e" も必須。
+//	https://datatracker.ietf.org/doc/html/rfc7517#section-4
+func TestJWKS_RequiredFields(t *testing.T) {
+	require.NoError(t, utils.InitializeKeys())
+
+	handler := oidc.NewDiscoveryHandler(newDiscoveryCfg())
+
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/oauth/jwks", nil)
-
-	// Act
 	handler.HandleJWKS(c)
 
-	// Assert
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), "keys")
-}
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 
-// TestJWKSHandler_ResponseFormat tests JWKS response format
-func TestJWKSHandler_ResponseFormat(t *testing.T) {
-	// Arrange
-	// Initialize keys before testing JWKS
-	err := utils.InitializeKeys()
-	if err != nil {
-		t.Fatalf("Failed to initialize keys: %v", err)
-	}
+	keys, ok := resp["keys"].([]interface{})
+	require.True(t, ok, "keys array must be present")
+	require.NotEmpty(t, keys)
 
-	cfg := &config.Config{
-		ServerHost: "https://test.example.com",
-	}
-
-	handler := oidc.NewDiscoveryHandler(cfg)
-	
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodGet, "/oauth/jwks", nil)
-
-	// Act
-	handler.HandleJWKS(c)
-
-	// Assert
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+	key := keys[0].(map[string]interface{})
+	// RFC 7517 §4.1: kty は REQUIRED
+	assert.Equal(t, "RSA", key["kty"])
+	// RFC 7517 §6.3: RSA 公開鍵パラメータ
+	assert.NotEmpty(t, key["n"], "RSA modulus (n) must be present")
+	assert.NotEmpty(t, key["e"], "RSA exponent (e) must be present")
+	// RFC 7517 §4.2: use (公開鍵の用途)
+	assert.Equal(t, "sig", key["use"])
 }

--- a/backend/test/utils/jwt_test.go
+++ b/backend/test/utils/jwt_test.go
@@ -8,282 +8,236 @@ import (
 	"openid-aas/backend/utils"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// TestInitializeKeys tests RSA key pair generation
+func setup(t *testing.T) {
+	t.Helper()
+	require.NoError(t, utils.InitializeKeys())
+}
+
+// TestInitializeKeys は RSA 鍵ペアの生成をテストする。
+//
+// Ref: OpenID Connect Core 1.0 §10.1
+//
+//	"Servers SHOULD use RS256 or better RSA-based algorithms with a key size of 2048 bits or larger."
+//	https://openid.net/specs/openid-connect-core-1_0.html#SigEnc
 func TestInitializeKeys(t *testing.T) {
-	// Arrange
-	// (no setup needed)
-
-	// Act
-	err := utils.InitializeKeys()
-
-	// Assert
-	if err != nil {
-		t.Errorf("InitializeKeys() returned error: %v", err)
-	}
-	if utils.GetPublicKey() == nil {
-		t.Error("InitializeKeys() failed to initialize public key")
-	}
+	require.NoError(t, utils.InitializeKeys())
+	assert.NotNil(t, utils.GetPublicKey())
+	assert.Equal(t, 2048, utils.GetPublicKey().N.BitLen(), "RSA key must be at least 2048 bits")
 }
 
-// TestGetPublicKey tests retrieving the public key
-func TestGetPublicKey(t *testing.T) {
-	// Arrange
-	err := utils.InitializeKeys()
-	if err != nil {
-		t.Fatalf("Failed to setup test: %v", err)
-	}
+// TestGenerateIDToken_RequiredClaims は ID トークンに必須クレームが含まれることを検証する。
+//
+// Ref: OpenID Connect Core 1.0 §2 (ID Token)
+//
+//	必須クレーム: iss, sub, aud, exp, iat
+//	https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+func TestGenerateIDToken_RequiredClaims(t *testing.T) {
+	setup(t)
 
-	// Act
-	key := utils.GetPublicKey()
+	tokenStr, err := utils.GenerateIDToken(
+		"user-sub-123", "Test User", "test@example.com", "",
+		"", "client-abc", "https://issuer.example.com",
+		true, 3600,
+	)
+	require.NoError(t, err)
 
-	// Assert
-	if key == nil {
-		t.Error("GetPublicKey() returned nil")
-	}
-}
-
-// TestGenerateAccessToken tests access token generation
-func TestGenerateAccessToken(t *testing.T) {
-	// Arrange
-	err := utils.InitializeKeys()
-	if err != nil {
-		t.Fatalf("Failed to setup test: %v", err)
-	}
-
-	sub := "user123"
-	name := "Test User"
-	email := "test@example.com"
-	picture := "https://example.com/pic.jpg"
-	scope := "openid profile email"
-	clientID := "client123"
-	issuer := "https://example.com"
-	emailVerified := true
-	expirySeconds := 3600
-
-	// Act
-	token, err := utils.GenerateAccessToken(sub, name, email, picture, scope, clientID, issuer, emailVerified, expirySeconds)
-
-	// Assert
-	if err != nil {
-		t.Errorf("GenerateAccessToken() returned error: %v", err)
-	}
-	if token == "" {
-		t.Error("GenerateAccessToken() returned empty token")
-	}
-	// Verify token has JWT format (three parts separated by dots)
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		t.Errorf("GenerateAccessToken() returned invalid JWT format, got %d parts, want 3", len(parts))
-	}
-}
-
-// TestGenerateAccessToken_VerifyClaims tests that access token contains correct claims
-func TestGenerateAccessToken_VerifyClaims(t *testing.T) {
-	// Arrange
-	err := utils.InitializeKeys()
-	if err != nil {
-		t.Fatalf("Failed to setup test: %v", err)
-	}
-
-	sub := "user123"
-	name := "Test User"
-	email := "test@example.com"
-	picture := "https://example.com/pic.jpg"
-	scope := "openid profile email"
-	clientID := "client123"
-	issuer := "https://example.com"
-	emailVerified := true
-	expirySeconds := 3600
-
-	// Act
-	tokenString, err := utils.GenerateAccessToken(sub, name, email, picture, scope, clientID, issuer, emailVerified, expirySeconds)
-	if err != nil {
-		t.Fatalf("Failed to generate token: %v", err)
-	}
-
-	// Assert - Parse and verify claims
-	token, err := jwt.ParseWithClaims(tokenString, &utils.Claims{}, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &utils.Claims{}, func(t *jwt.Token) (interface{}, error) {
 		return utils.GetPublicKey(), nil
 	})
-	if err != nil {
-		t.Errorf("Failed to parse token: %v", err)
-	}
+	require.NoError(t, err)
+	require.True(t, token.Valid)
 
-	if claims, ok := token.Claims.(*utils.Claims); ok && token.Valid {
-		if claims.Sub != sub {
-			t.Errorf("Sub = %v, want %v", claims.Sub, sub)
-		}
-		if claims.Name != name {
-			t.Errorf("Name = %v, want %v", claims.Name, name)
-		}
-		if claims.Email != email {
-			t.Errorf("Email = %v, want %v", claims.Email, email)
-		}
-	} else {
-		t.Error("Failed to extract claims from token")
-	}
+	claims, ok := token.Claims.(*utils.Claims)
+	require.True(t, ok)
+
+	// OpenID Connect Core 1.0 §2: iss は REQUIRED
+	assert.Equal(t, "https://issuer.example.com", claims.Issuer)
+	// OpenID Connect Core 1.0 §2: sub は REQUIRED (最大255文字の ASCII)
+	// Note: Claims.Sub (json:"sub") が RegisteredClaims.Subject (json:"sub") より
+	// 浅いため、パース後は Claims.Sub に格納される。
+	assert.Equal(t, "user-sub-123", claims.Sub)
+	// OpenID Connect Core 1.0 §2: aud は REQUIRED (client_id を含む)
+	assert.Contains(t, []string(claims.Audience), "client-abc")
+	// OpenID Connect Core 1.0 §2: exp は REQUIRED
+	assert.True(t, claims.ExpiresAt.After(time.Now()))
+	// OpenID Connect Core 1.0 §2: iat は REQUIRED
+	assert.NotNil(t, claims.IssuedAt)
 }
 
-// TestGenerateIDToken tests ID token generation
-func TestGenerateIDToken(t *testing.T) {
-	// Arrange
-	err := utils.InitializeKeys()
-	if err != nil {
-		t.Fatalf("Failed to setup test: %v", err)
-	}
+// TestGenerateIDToken_WithNonce は nonce クレームが正しく含まれることを検証する。
+//
+// Ref: OpenID Connect Core 1.0 §3.1.2.2
+//
+//	"If a nonce value was sent in the Authentication Request, a nonce Claim
+//	 MUST be present and its value checked to verify that it is the same value
+//	 as the one that was sent in the Authentication Request."
+//	https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+func TestGenerateIDToken_WithNonce(t *testing.T) {
+	setup(t)
 
-	sub := "user123"
-	name := "Test User"
-	email := "test@example.com"
-	picture := "https://example.com/pic.jpg"
-	nonce := "random-nonce"
-	clientID := "client123"
-	issuer := "https://example.com"
-	emailVerified := true
+	nonce := "unique-nonce-value-xyz"
+	tokenStr, err := utils.GenerateIDToken(
+		"sub", "Name", "email@example.com", "",
+		nonce, "client-id", "https://issuer.example.com",
+		true, 3600,
+	)
+	require.NoError(t, err)
+
+	// nonce は MapClaims で埋め込まれるため ParseWithClaims[MapClaims] で検証
+	token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+		return utils.GetPublicKey(), nil
+	})
+	require.NoError(t, err)
+
+	mc, ok := token.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+	assert.Equal(t, nonce, mc["nonce"])
+}
+
+// TestGenerateIDToken_SignedWithRS256 は ID トークンが RS256 で署名されることを検証する。
+//
+// Ref: OpenID Connect Core 1.0 §10.1
+//
+//	"Servers MUST support RS256."
+//	https://openid.net/specs/openid-connect-core-1_0.html#SigEnc
+func TestGenerateIDToken_SignedWithRS256(t *testing.T) {
+	setup(t)
+
+	tokenStr, err := utils.GenerateIDToken(
+		"sub", "Name", "email@example.com", "",
+		"", "client-id", "https://issuer.example.com",
+		true, 3600,
+	)
+	require.NoError(t, err)
+
+	// ヘッダーの alg フィールドを確認（検証なしでパース）
+	parts := strings.Split(tokenStr, ".")
+	require.Len(t, parts, 3, "JWT must have 3 parts")
+
+	token, _ := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+		return utils.GetPublicKey(), nil
+	})
+	assert.IsType(t, jwt.SigningMethodRS256, token.Method)
+}
+
+// TestGenerateIDToken_Expiry は exp クレームが正しく設定されることを検証する。
+//
+// Ref: RFC 7519 §4.1.4
+//
+//	"The "exp" (expiration time) claim identifies the expiration time on or after
+//	 which the JWT MUST NOT be accepted for processing."
+//	https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
+func TestGenerateIDToken_Expiry(t *testing.T) {
+	setup(t)
+
 	expirySeconds := 3600
+	before := time.Now()
 
-	// Act
-	token, err := utils.GenerateIDToken(sub, name, email, picture, nonce, clientID, issuer, emailVerified, expirySeconds)
+	tokenStr, err := utils.GenerateIDToken(
+		"sub", "Name", "email@example.com", "",
+		"", "client-id", "https://issuer.example.com",
+		true, expirySeconds,
+	)
+	require.NoError(t, err)
 
-	// Assert
-	if err != nil {
-		t.Errorf("GenerateIDToken() returned error: %v", err)
-	}
-	if token == "" {
-		t.Error("GenerateIDToken() returned empty token")
-	}
+	token, err := jwt.ParseWithClaims(tokenStr, &utils.Claims{}, func(t *jwt.Token) (interface{}, error) {
+		return utils.GetPublicKey(), nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(*utils.Claims)
+	expectedExpiry := before.Add(time.Duration(expirySeconds) * time.Second)
+	// 1秒の誤差を許容
+	assert.WithinDuration(t, expectedExpiry, claims.ExpiresAt.Time, time.Second)
 }
 
-// TestValidateToken tests token validation
-func TestValidateToken(t *testing.T) {
-	// Arrange
-	err := utils.InitializeKeys()
-	if err != nil {
-		t.Fatalf("Failed to setup test: %v", err)
-	}
+// TestValidateToken_ValidToken は有効なトークンの検証が成功することをテストする。
+//
+// Ref: RFC 7519 §7.2 (Validating a JWT)
+//
+//	https://datatracker.ietf.org/doc/html/rfc7519#section-7.2
+func TestValidateToken_ValidToken(t *testing.T) {
+	setup(t)
 
-	sub := "user123"
-	name := "Test User"
-	email := "test@example.com"
-	picture := "https://example.com/pic.jpg"
-	scope := "openid profile email"
-	clientID := "client123"
-	issuer := "https://example.com"
-	emailVerified := true
-	expirySeconds := 3600
+	tokenStr, err := utils.GenerateAccessToken(
+		"sub", "Name", "email@example.com", "",
+		"openid profile", "client-id", "https://issuer.example.com",
+		true, 3600,
+	)
+	require.NoError(t, err)
 
-	tokenString, err := utils.GenerateAccessToken(sub, name, email, picture, scope, clientID, issuer, emailVerified, expirySeconds)
-	if err != nil {
-		t.Fatalf("Failed to setup test: %v", err)
-	}
-
-	// Act
-	claims, err := utils.ValidateToken(tokenString)
-
-	// Assert
-	if err != nil {
-		t.Errorf("ValidateToken() returned error: %v", err)
-	}
-	if claims == nil {
-		t.Error("ValidateToken() returned nil claims")
-	}
-	if claims.Sub != sub {
-		t.Errorf("Claims.Sub = %v, want %v", claims.Sub, sub)
-	}
+	claims, err := utils.ValidateToken(tokenStr)
+	require.NoError(t, err)
+	assert.Equal(t, "sub", claims.Sub)
 }
 
-// TestValidateToken_InvalidToken tests validation with invalid token
-func TestValidateToken_InvalidToken(t *testing.T) {
-	// Arrange
-	err := utils.InitializeKeys()
-	if err != nil {
-		t.Fatalf("Failed to setup test: %v", err)
-	}
-	invalidToken := "invalid.token.string"
-
-	// Act
-	claims, err := utils.ValidateToken(invalidToken)
-
-	// Assert
-	if err == nil {
-		t.Error("ValidateToken() expected error for invalid token, got nil")
-	}
-	if claims != nil {
-		t.Errorf("ValidateToken() returned claims = %v, want nil", claims)
-	}
-}
-
-// TestValidateToken_ExpiredToken tests validation with expired token
+// TestValidateToken_ExpiredToken は期限切れトークンの検証が失敗することをテストする。
+//
+// Ref: RFC 7519 §4.1.4
+//
+//	"The current date/time MUST be before the expiration date/time listed in the "exp" Claim."
+//	https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
 func TestValidateToken_ExpiredToken(t *testing.T) {
-	// Arrange
-	err := utils.InitializeKeys()
-	if err != nil {
-		t.Fatalf("Failed to setup test: %v", err)
-	}
+	setup(t)
 
-	sub := "user123"
-	name := "Test User"
-	email := "test@example.com"
-	picture := "https://example.com/pic.jpg"
-	scope := "openid profile email"
-	clientID := "client123"
-	issuer := "https://example.com"
-	emailVerified := true
-	expirySeconds := -1 // Expired token (negative expiry)
+	tokenStr, err := utils.GenerateAccessToken(
+		"sub", "Name", "email@example.com", "",
+		"openid", "client-id", "https://issuer.example.com",
+		true, -1, // 既に期限切れ
+	)
+	require.NoError(t, err)
 
-	tokenString, err := utils.GenerateAccessToken(sub, name, email, picture, scope, clientID, issuer, emailVerified, expirySeconds)
-	if err != nil {
-		t.Fatalf("Failed to setup test: %v", err)
-	}
+	time.Sleep(10 * time.Millisecond)
 
-	// Wait a moment to ensure token is expired
-	time.Sleep(100 * time.Millisecond)
+	claims, err := utils.ValidateToken(tokenStr)
+	assert.Error(t, err, "expired token must be rejected")
+	assert.Nil(t, claims)
+}
 
-	// Act
-	claims, err := utils.ValidateToken(tokenString)
+// TestValidateToken_InvalidSignature は署名が不正なトークンの検証が失敗することをテストする。
+//
+// Ref: RFC 7519 §7.2 step 8
+//
+//	"Validate the JWT Signature."
+//	https://datatracker.ietf.org/doc/html/rfc7519#section-7.2
+func TestValidateToken_InvalidSignature(t *testing.T) {
+	setup(t)
 
-	// Assert
-	if err == nil {
-		t.Error("ValidateToken() expected error for expired token, got nil")
-	}
-	if claims != nil {
-		t.Errorf("ValidateToken() returned claims = %v, want nil for expired token", claims)
+	claims, err := utils.ValidateToken("invalid.token.string")
+	assert.Error(t, err)
+	assert.Nil(t, claims)
+}
+
+// TestGenerateRandomString_Length は生成された文字列が指定長であることをテストする。
+//
+// Ref: RFC 6749 §10.10
+//
+//	認可コードやトークンは十分なエントロピーを持つランダム値であるべき。
+//	https://datatracker.ietf.org/doc/html/rfc6749#section-10.10
+func TestGenerateRandomString_Length(t *testing.T) {
+	for _, length := range []int{16, 32, 64} {
+		str, err := utils.GenerateRandomString(length)
+		require.NoError(t, err)
+		assert.Equal(t, length, len(str), "length=%d", length)
 	}
 }
 
-// TestGenerateRandomString tests random string generation
-func TestGenerateRandomString(t *testing.T) {
-	// Arrange
-	length := 32
-
-	// Act
-	str, err := utils.GenerateRandomString(length)
-
-	// Assert
-	if err != nil {
-		t.Errorf("GenerateRandomString() returned error: %v", err)
-	}
-	if len(str) != length {
-		t.Errorf("GenerateRandomString() returned string of length %d, want %d", len(str), length)
-	}
-}
-
-// TestGenerateRandomString_Uniqueness tests that random strings are unique
+// TestGenerateRandomString_Uniqueness は連続生成した文字列が重複しないことをテストする。
+//
+// Ref: RFC 6749 §10.10
+//
+//	https://datatracker.ietf.org/doc/html/rfc6749#section-10.10
 func TestGenerateRandomString_Uniqueness(t *testing.T) {
-	// Arrange
-	length := 32
-
-	// Act
-	str1, err1 := utils.GenerateRandomString(length)
-	str2, err2 := utils.GenerateRandomString(length)
-
-	// Assert
-	if err1 != nil || err2 != nil {
-		t.Errorf("GenerateRandomString() returned errors: %v, %v", err1, err2)
-	}
-	if str1 == str2 {
-		t.Error("GenerateRandomString() produced identical strings")
+	seen := make(map[string]struct{})
+	for i := 0; i < 100; i++ {
+		s, err := utils.GenerateRandomString(32)
+		require.NoError(t, err)
+		_, dup := seen[s]
+		assert.False(t, dup, "duplicate random string generated")
+		seen[s] = struct{}{}
 	}
 }


### PR DESCRIPTION
## Summary

- テストケースに RFC / OIDC 仕様書へのコメント参照を付与
- ハンドラを実際に呼び出す意味のあるテストに書き直す
- pgxmock を追加し DB 操作のモックテストを実装

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `handlers/oidc/token_test.go` | `scopeContains` の回帰テスト（RFC 6749 §3.3）。`fix/scope-contains-bug` マージ後に通る |
| `test/handlers/admin/auth_test.go` | `HandleLogin` / `HandleLogout` を pgxmock で検証。bcrypt 検証・レスポンス形状・必須フィールド欠落を網羅 |
| `test/handlers/admin/clients_test.go` | クライアント CRUD を pgxmock で検証（RFC 7591 参照） |
| `test/handlers/admin/users_test.go` | ユーザー管理を pgxmock で検証（OIDC Core §5.1 参照） |
| `test/handlers/middleware/auth_test.go` | `AdminAuth` ミドルウェアを pgxmock で検証 |
| `test/handlers/oidc/discovery_test.go` | Discovery ドキュメントの必須フィールド・issuer・PKCE メソッド等を検証（OIDC Discovery §3、RFC 7636 参照） |
| `test/utils/jwt_test.go` | ID トークンの必須クレーム・nonce・署名アルゴリズムを検証（RFC 7519、OIDC Core §2 参照） |

## 現状の CI 状態

- `token_test.go`（`scopeContains`）: `fix/scope-contains-bug` マージ前はビルドエラー
- admin / middleware の pgxmock テスト: `database.Pool` インターフェース導入前はコンパイルエラー
- `discovery_test.go` / `jwt_test.go`: 通過予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)