### PR TITLE
ci: run backend CI on PRs to both main and develop

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "main", "develop" ]
     paths:
       - "backend/**"
 


### PR DESCRIPTION
## Summary
- `pull_request.branches` に `main` を追加
- `develop` と `main` 両方へのPRでバックエンドCIが実行されるようになる

## Test plan
- [ ] `develop` へのPRでCIが実行されることを確認
- [ ] `main` へのPRでCIが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)